### PR TITLE
Use standardized `maintainer` metadata property value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=Arduino_CloudConnectionFeedback
 version=0.2.0
 author=Alessandro Ranellucci
-maintainer=Alessandro Ranellucci <a.ranellucci@arduino.cc>
+maintainer=Arduino <info@arduino.cc>
 sentence=Block program execution until the device is connected to the cloud and provide user with feedback on connection status.
 paragraph=Blocks program execution until the device is connected to the cloud and provides users with feedback on connection status.
 category=Communication


### PR DESCRIPTION
The `maintainer` property of the [`library.properties` metadata file](https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata) defines the entity responsible for maintenance of the library.

In the libraries that are under Arduino's maintainership, it is standard practice to set the `maintainer` property to the general purpose value `Arduino <info@arduino.cc>`.

Previously, instead of that standard value, this library's `maintainer` property defined a specific Arduino team member as the maintainer. This is prone to "bit rot", as the scope of each individual's work may change over time, or they may even move on from working for Arduino. It is unlikely that the team member will remember to update the metadata values at such time as they are no longer able to dedicate themselves to maintaining the library. So the metadata is changed to use the standard value.

It is commendable for individual team members to take responsibility for maintenance of specific libraries. However, doing so is not in any way dependent on the value of a metadata property. The change to the metadata does not imply any change to maintenance responsibilities for the project.